### PR TITLE
removes apt update to simplify pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   dotnet-core-sdk:
     docker:
-    - image: mcr.microsoft.com/dotnet/core/sdk:3.1.402-alpine3.12
+    - image: mcr.microsoft.com/dotnet/core/sdk:3.1
   docker-publisher:
     environment:
       IMAGE_NAME: openftth/desktop-bridge
@@ -15,9 +15,6 @@ jobs:
     executor: dotnet-core-sdk
     steps:
       - checkout
-      - run:
-          name: Apt update
-          command: apt-get update;
       - run:
           name: Install taskfile
           command: curl -sL https://taskfile.dev/install.sh | sh
@@ -32,9 +29,6 @@ jobs:
     executor: dotnet-core-sdk
     steps:
       - checkout
-      - run:
-          name: Apt update
-          command: apt-get update;
       - run:
           name: Install taskrunner
           command: curl -sL https://taskfile.dev/install.sh | sh


### PR DESCRIPTION
Revert back to image: mcr.microsoft.com/dotnet/core/sdk:3.1 from mcr.microsoft.com/dotnet/core/sdk:3.1.402-alpine3.12 since git is needed for circleci.