### PR TITLE
optimizes the geographical updated consumer

### DIFF
--- a/src/OpenFTTH.DesktopBridge/GeographicalAreaUpdated/GeographicalAreaUpdatedKafkaConsumer.cs
+++ b/src/OpenFTTH.DesktopBridge/GeographicalAreaUpdated/GeographicalAreaUpdatedKafkaConsumer.cs
@@ -31,7 +31,12 @@ namespace OpenFTTH.DesktopBridge.GeographicalAreaUpdated
                 .Serialization(s => s.UseNewtonsoftJson())
                 .Topics(t => t.Subscribe(_kafkaSetting.NotificationGeographicalAreaUpdated))
                 .Logging(x => x.UseSerilog())
-                .Positions(p => p.StoreInFileSystem(_kafkaSetting.PositionFilePath))
+                .Positions(x =>
+                {
+                    x.SetInitialPosition(StartFromPosition.Now);
+                    x.StoreInMemory();
+                })
+                .Options(x => { x.SetMinimumBatchSize(1); })
                 .Handle(async (messages, context, token) =>
                 {
                     foreach (var message in messages)


### PR DESCRIPTION
Optimizes the geographical updated consumer by using current position and setting minimum batch size to 1 to avoid wait time.