### PR TITLE
Add missing unit test for mapping PanToCoordinate

### DIFF
--- a/test/OpenFTTH.DesktopBridge.Tests/Event/EventMapperTest.cs
+++ b/test/OpenFTTH.DesktopBridge.Tests/Event/EventMapperTest.cs
@@ -4,6 +4,7 @@ using OpenFTTH.DesktopBridge.IdentifyNetwork;
 using OpenFTTH.DesktopBridge.Event;
 using OpenFTTH.DesktopBridge.Retrieve;
 using OpenFTTH.DesktopBridge.Highlight;
+using OpenFTTH.DesktopBridge.Pan;
 using FluentAssertions;
 
 namespace OpenFTTH.DesktopBridge.Tests
@@ -14,6 +15,7 @@ namespace OpenFTTH.DesktopBridge.Tests
         [InlineData("{ \"eventType\": \"IdentifyNetworkElement\" }", typeof(IdentifyNetworkElement))]
         [InlineData("{ \"eventType\": \"RetrieveSelected\" }", typeof(RetrieveSelected))]
         [InlineData("{ \"eventType\": \"RetrieveSelectedResponse\" }", typeof(RetrieveSelectedResponse))]
+        [InlineData("{ \"eventType\": \"PanToCoordinate\" }", typeof(PanToCoordinate))]
         [InlineData("{ \"eventType\": \"HighlightFeatures\" }", typeof(HighlightFeatures))]
         public void Map_ShouldReturnCorrectlyParsedType_OnReceivedJsonEvent(string jsonEvent, Type expectedType)
         {


### PR DESCRIPTION
Adds the missing unit that test if the mapping for `PanToCoordinate` event is correct.