### PR TITLE
switch to ca-patch to fix image issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   dotnet-core-sdk:
     docker:
-    - image: mcr.microsoft.com/dotnet/sdk:5.0
+    - image: mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
       auth:
         username: $DOCKER_LOGIN
         password: $DOCKER_ACCESSTOKEN

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build-env
 WORKDIR /app
 
 COPY ./*sln ./


### PR DESCRIPTION
There are currently issues with the image for dotnet-sdk 5.0. Switch to the hotfix image to solve this issue.