### PR TITLE
fixes dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
-bin\
-obj\
+**/bin/
+**/obj/
+.git
+.cache
+*.md


### PR DESCRIPTION
Fixes the issue where you cannot build images on Linux hosts. Building an image on a Linux host resulting in the following error: `error checking context: 'syntax error in pattern'.`.