### PR TITLE
ping the clients to keep the connection alive

### DIFF
--- a/src/OpenFTTH.DesktopBridge/Bridge/BridgeServer.cs
+++ b/src/OpenFTTH.DesktopBridge/Bridge/BridgeServer.cs
@@ -4,10 +4,12 @@ using NetCoreServer;
 using Microsoft.Extensions.Logging;
 using MediatR;
 using OpenFTTH.DesktopBridge.Event;
+using System;
+using System.Threading;
 
 namespace OpenFTTH.DesktopBridge.Bridge
 {
-    public class BridgeServer : WsServer, IBridgeServer
+    public class BridgeServer : WsServer, IBridgeServer, IDisposable
     {
         private readonly ILogger<BridgeServer> _logger;
         private readonly IMediator _mediator;
@@ -23,12 +25,18 @@ namespace OpenFTTH.DesktopBridge.Bridge
 
         protected override TcpSession CreateSession()
         {
+            var t = new Timer(o => Ping(), null, 0, 30000);
             return new BridgeSession(this, _logger, _mediator, _eventMapper);
         }
 
         protected override void OnError(SocketError error)
         {
             _logger.LogError($"Chat WebSocket server caught an error with code {error}");
+        }
+
+        private void Ping()
+        {
+            SendPing("ping");
         }
     }
 }

--- a/src/OpenFTTH.DesktopBridge/Bridge/BridgeServer.cs
+++ b/src/OpenFTTH.DesktopBridge/Bridge/BridgeServer.cs
@@ -4,18 +4,22 @@ using NetCoreServer;
 using Microsoft.Extensions.Logging;
 using MediatR;
 using OpenFTTH.DesktopBridge.Event;
-using System;
 using System.Threading;
 
 namespace OpenFTTH.DesktopBridge.Bridge
 {
-    public class BridgeServer : WsServer, IBridgeServer, IDisposable
+    public class BridgeServer : WsServer, IBridgeServer
     {
         private readonly ILogger<BridgeServer> _logger;
         private readonly IMediator _mediator;
         private readonly IEventMapper _eventMapper;
+        private Timer _timer;
 
-        public BridgeServer(IPAddress address, int port, ILogger<BridgeServer> logger, IMediator mediator, IEventMapper eventMapper) : base(address, port)
+        public BridgeServer(IPAddress address,
+                            int port,
+                            ILogger<BridgeServer> logger,
+                            IMediator mediator,
+                            IEventMapper eventMapper) : base(address, port)
         {
             _logger = logger;
             _mediator = mediator;
@@ -25,8 +29,13 @@ namespace OpenFTTH.DesktopBridge.Bridge
 
         protected override TcpSession CreateSession()
         {
-            var t = new Timer(o => Ping(), null, 0, 30000);
             return new BridgeSession(this, _logger, _mediator, _eventMapper);
+        }
+
+        protected override void OnStarted()
+        {
+            base.OnStarted();
+            _timer = new Timer(o => Ping(), null, 0, 30000);
         }
 
         protected override void OnError(SocketError error)
@@ -34,8 +43,14 @@ namespace OpenFTTH.DesktopBridge.Bridge
             _logger.LogError($"Chat WebSocket server caught an error with code {error}");
         }
 
+        protected override void OnStopped()
+        {
+            _timer.Dispose();
+        }
+
         private void Ping()
         {
+            _logger.LogInformation("Pinging clients");
             SendPing("ping");
         }
     }


### PR DESCRIPTION
Ping the clients to keep the connection alive. The current implementation is to ping the clients every 30 second. This should be enough time since the default ingress controller setup is 60 second before it disconnects an idle client.