### PR TITLE
can now handle retrieve identified network element event

### DIFF
--- a/src/OpenFTTH.DesktopBridge/Event/EventMapper.cs
+++ b/src/OpenFTTH.DesktopBridge/Event/EventMapper.cs
@@ -22,6 +22,8 @@ namespace OpenFTTH.DesktopBridge.Event
             {
                 case "IdentifyNetworkElement":
                     return JsonConvert.DeserializeObject<IdentifyNetworkElement>(jsonEvent);
+                case "RetrieveIdentifiedNetworkElement":
+                    return JsonConvert.DeserializeObject<RetrieveIdentifiedNetworkElement>(jsonEvent);
                 case "RetrieveSelected":
                     return JsonConvert.DeserializeObject<RetrieveSelected>(jsonEvent);
                 case "RetrieveSelectedResponse":

--- a/src/OpenFTTH.DesktopBridge/IdentifyNetwork/RetrieveIdentifiedNetworkElement.cs
+++ b/src/OpenFTTH.DesktopBridge/IdentifyNetwork/RetrieveIdentifiedNetworkElement.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace OpenFTTH.DesktopBridge.IdentifyNetwork
+{
+    public class RetrieveIdentifiedNetworkElement : IRequest<Unit>
+    {
+        public string EventType { get; set; }
+        public string Username { get; set; }
+    }
+}

--- a/src/OpenFTTH.DesktopBridge/IdentifyNetwork/RetrieveIdentifiedNetworkElementHandler.cs
+++ b/src/OpenFTTH.DesktopBridge/IdentifyNetwork/RetrieveIdentifiedNetworkElementHandler.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using OpenFTTH.DesktopBridge.Bridge;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace OpenFTTH.DesktopBridge.IdentifyNetwork
+{
+    public class RetrieveIdentifiedNetworkElementhandler : IRequestHandler<RetrieveIdentifiedNetworkElement>
+    {
+        private readonly IBridgeServer _bridgeServer;
+
+        public RetrieveIdentifiedNetworkElementhandler(IBridgeServer bridgeServer)
+        {
+            _bridgeServer = bridgeServer;
+        }
+
+        public async Task<Unit> Handle(RetrieveIdentifiedNetworkElement request, CancellationToken cancellationToken)
+        {
+            _bridgeServer.MulticastText(JsonConvert.SerializeObject(request));
+            return await Task.FromResult(new Unit());
+        }
+    }
+}

--- a/test/OpenFTTH.DesktopBridge.Tests/Event/EventMapperTest.cs
+++ b/test/OpenFTTH.DesktopBridge.Tests/Event/EventMapperTest.cs
@@ -13,6 +13,7 @@ namespace OpenFTTH.DesktopBridge.Tests
     {
         [Theory]
         [InlineData("{ \"eventType\": \"IdentifyNetworkElement\" }", typeof(IdentifyNetworkElement))]
+        [InlineData("{ \"eventType\": \"RetrieveIdentifiedNetworkElement\" }", typeof(RetrieveIdentifiedNetworkElement))]
         [InlineData("{ \"eventType\": \"RetrieveSelected\" }", typeof(RetrieveSelected))]
         [InlineData("{ \"eventType\": \"RetrieveSelectedResponse\" }", typeof(RetrieveSelectedResponse))]
         [InlineData("{ \"eventType\": \"PanToCoordinate\" }", typeof(PanToCoordinate))]

--- a/test/OpenFTTH.DesktopBridge.Tests/IdentifyNetwork/RetrieveIdentifiedNetworkElementTest.cs
+++ b/test/OpenFTTH.DesktopBridge.Tests/IdentifyNetwork/RetrieveIdentifiedNetworkElementTest.cs
@@ -1,0 +1,24 @@
+using FakeItEasy;
+using Xunit;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenFTTH.DesktopBridge.Bridge;
+using OpenFTTH.DesktopBridge.IdentifyNetwork;
+
+namespace OpenFTTH.DesktopBridge.Tests.IdentifyNetwork
+{
+    public class RetriveIdentifiedNetworkElementTest
+    {
+        [Fact]
+        public async Task Handle_MulticastsBase64EncodedJsonUpdatedMessage_OnBeingCalled()
+        {
+            var bridgeServer = A.Fake<IBridgeServer>();
+            var retrieveEvent = A.Fake<RetrieveIdentifiedNetworkElement>();
+
+            var handler = new RetrieveIdentifiedNetworkElementhandler(bridgeServer);
+            var result = await handler.Handle(retrieveEvent, new CancellationToken());
+
+            A.CallTo(() => bridgeServer.MulticastText(A<string>._)).MustHaveHappenedOnceExactly();
+        }
+    }
+}


### PR DESCRIPTION
Can now handle the `RetrieveIdentifiedNetworkElement` event that is needed in the fronted to get the initial state of the identified network element.