### PR TITLE
server now pings all the connected clients every 30 seconds

### DIFF
--- a/src/OpenFTTH.DesktopBridge/OpenFTTH.DesktopBridge.csproj
+++ b/src/OpenFTTH.DesktopBridge/OpenFTTH.DesktopBridge.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="mediatr" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="NetCoreServer" Version="6.7.0" />
+    <PackageReference Include="NetCoreServer" Version="8.0.7" />
     <PackageReference Include="OpenFTTH.NotificationClient" Version="0.2.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />


### PR DESCRIPTION
Might fix issue with clients being reset by the cloud providers load balancers. This is done because we have had issues where the cloud providers have disconnected our clients every 30 minutes and this can result in issues when clients need to be reconnected.

The server now sends out 'ping' every 30 seconds to all connected clients to make sure that the clients are connected.